### PR TITLE
Removed os.Exit calls from the package along with default logging. Fixed minor bugs and design improvements

### DIFF
--- a/.github/workflows/test_grpc.yml
+++ b/.github/workflows/test_grpc.yml
@@ -1,0 +1,27 @@
+on:
+  # Trigger the workflow on push request if the files
+  # in ./pubsub package were modified
+  push:
+    paths:
+      - grpc/**
+
+name: test
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17'
+
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v2
+        with:
+          working-directory: ./grpc/
+
+      - name: Run tests
+        run: make test -C ./grpc

--- a/go.mod
+++ b/go.mod
@@ -9,8 +9,10 @@ require (
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/go-chi/chi/v5 v5.0.5
 	github.com/go-chi/cors v1.2.0
+	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.3.0
 	github.com/matryer/is v1.4.0
+	github.com/oklog/run v1.1.0
 	github.com/pkg/errors v0.9.1
 	github.com/rs/cors v1.7.0
 	github.com/streadway/amqp v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,7 @@ github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/me
 github.com/gofrs/flock v0.8.0/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
+github.com/gogo/protobuf v1.2.1 h1:/s5zKNz0uPFCZ5hddgPdo2TK2TVrUNMn0OOX8/aZMTE=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
@@ -199,6 +200,7 @@ github.com/googleapis/gax-go/v2 v2.1.1/go.mod h1:hddJymUZASv3XPyGkUpKj8pPO47Rmb0
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf/go.mod h1:cuNKsD1zp2v6XfE/orVX2QE1LC+i254ceGcVeDT3pTU=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/grpc-ecosystem/go-grpc-middleware v1.0.0 h1:Iju5GlWwrvL6UBg4zJJt3btmonfrMlCDdsejg4CZE7c=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
@@ -244,6 +246,7 @@ github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvW
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/pgzip v1.2.5/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
+github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
@@ -270,6 +273,8 @@ github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJ
 github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
+github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
@@ -300,6 +305,7 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
+github.com/sirupsen/logrus v1.2.0 h1:juTguoYk5qI21pwyTXY3B3Y5cOTH3ZUyZCg1v/mihuo=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -361,6 +367,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190605123033-f99c8df09eb5/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=

--- a/grpc/.golangci.yml
+++ b/grpc/.golangci.yml
@@ -1,0 +1,171 @@
+# .golangci.yml
+run:
+  skip-dirs: vendor
+
+linters-settings:
+  staticcheck:
+    # Select the Go version to target. The default is '1.13'.
+    go: "1.17"
+    # https://staticcheck.io/docs/options#checks
+    checks: [ "all" ]
+
+  tagliatelle:
+    # Check the struck tag name case.
+    case:
+      # Use the struct field name to check the name of the struct tag.
+      # Default: false
+      use-field-name: true
+      rules:
+        # Any struct tag type can be used.
+        # Support string case: `camel`, `pascal`, `kebab`, `snake`, `goCamel`, `goPascal`, `goKebab`, `goSnake`, `upper`, `lower`
+        json: snake
+
+  dupl:
+    threshold: 300 # tokens count of duplicate code to trigger issue
+
+  goconst:
+    min-len: 2 # minimal length of string constant
+    min-occurrences: 2 # minimal occurrences count to trigger
+
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - experimental
+      - opinionated
+      - performance
+      - style
+    disabled-checks:
+      - dupImport # https://github.com/go-critic/go-critic/issues/845
+      - whyNoLint
+      - hugeParam
+
+  gocyclo:
+    min-complexity: 8 # minimal code cyclomatic complexity to report
+
+  gomnd:
+    settings:
+      mnd:
+        # don't include the "operation" and "assign"
+        checks: argument,case,condition,return
+
+  misspell:
+    locale: US
+
+  nolintlint:
+    allow-leading-space: true # don't require machine-readable nolint directives (i.e. with no leading space)
+    allow-unused: false # report any unused nolint directives
+    require-explanation: false # don't require an explanation for nolint directives
+    require-specific: false # don't require nolint directives to be specific about which linter is being skipped
+
+  gocognit:
+    min-complexity: 10 # minimal code cognitive complexity to report
+
+  gofumpt:
+    extra-rules: true
+
+  revive:
+    ignore-generated-header: true
+    rules:
+      - name: atomic
+      - name: line-length-limit
+        arguments: [ 80 ]
+      - name: context-keys-type
+      - name: time-naming
+      - name: var-declaration
+      - name: unexported-return
+      - name: errorf
+      - name: context-as-argument
+      - name: error-return
+      - name: error-strings
+      - name: error-naming
+      - name: exported
+      - name: increment-decrement
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: superfluous-else
+      - name: function-result-limit
+        arguments: [ 3 ]
+      - name: confusing-naming
+      - name: get-return
+      - name: modifies-parameter
+      - name: deep-exit
+      - name: flag-parameter
+      - name: modifies-value-receiver
+      - name: constant-logical-expr
+      - name: bool-literal-in-expr
+      - name: redefines-builtin-id
+      - name: range-val-in-closure
+      - name: range-val-address
+      - name: waitgroup-by-value
+      - name: atomic
+      - name: bare-return
+      - name: unused-receiver
+      - name: string-of-int
+      - name: early-return
+      - name: unconditional-recursion
+      - name: identical-branches
+      - name: defer
+      - name: unexported-naming
+      - name: nested-structs
+
+linters:
+  disable-all: true
+  enable:
+    - govet # Vet examines Go source code and reports suspicious constructs, only purpose of this tool is to detect go structs that would take less memory if their fields were sorted
+    - bodyclose # Detects whether the HTTP response body is closed successfully, not closing the response body could lead to memory leaks
+    - goconst # Finds repeated strings that could be replaced by a constant
+    - godot	# Check if comments end in a period
+    - gomnd	# An analyzer to detect magic numbers.
+    - goerr113 # Golang linter to check the errors handling expressions
+    - gocritic # Provides many diagnostics that check for bugs, performance and style issues.
+    - exhaustive # Check exhaustiveness of enum switch statements
+    - exportloopref	# checks for pointers to enclosing loop variables -- VERY IMPORTANT TO USE
+    - forcetypeassert #	finds forced type assertions
+    - importas # Enforces consistent import aliases
+    - gci # improves imports
+    - dupl # Detects code clones
+    - revive # Makes code style recomandations
+    - gocyclo # Computes and checks the cyclomatic complexity of functions
+    - gofumpt # Stricter gofmt
+    - deadcode #  Finds unused code
+    - errcheck # Checks unchecked errors in go programs
+    - gosimple # Linter for Go source code that specializes in simplifying a code
+    - ineffassign # Detects when assignments to existing variables are not used
+    - staticcheck # Staticcheck is a go vet on steroids, applying a ton of static analysis checks
+    - structcheck # Finds unused struct fields
+    - tagliatelle # Checks the struct tags.
+    - typecheck # Like the front-end of a Go compiler, parses and type-checks Go code
+    - thelper # thelper detects golang test helpers without t.Helper() call and checks the consistency of test helpers
+    - unused # Checks Go code for unused constants, variables, functions and types
+    - varcheck # Finds unused global variables and constants
+    - gocognit # Computes and checks the cognitive complexity of functions https://github.com/uudashr/gocognit
+    - gosec # Inspects source code for security problems
+    - prealloc # Finds slice declarations that could potentially be preallocated
+    - nolintlint # Reports ill-formed or insufficient nolint directives
+    - wsl # Whitespace Linter - Forces you to use empty lines!
+
+issues:
+  exclude-use-default: false
+  fix: true
+
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    # Exclude some linters from running on tests files.
+    - path: _test\.go
+      linters:
+        - gocyclo
+        - errcheck
+        - gosec
+        - gocognit
+        - forcetypeassert
+
+    - path: mock
+      linters:
+        - gomnd
+        - revive
+        - gocyclo
+        - errcheck
+        - dupl
+        - gosec
+        - forcetypeassert

--- a/grpc/Makefile
+++ b/grpc/Makefile
@@ -1,0 +1,4 @@
+test:
+	go test -race ./...
+lint:
+	golangci-lint run

--- a/grpc/gateway_server.go
+++ b/grpc/gateway_server.go
@@ -1,0 +1,104 @@
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+
+	"contrib.go.opencensus.io/exporter/stackdriver/propagation"
+	"github.com/go-chi/chi/v5"
+	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
+	"github.com/pkg/errors"
+	"github.com/rs/cors"
+	"go.opencensus.io/plugin/ocgrpc"
+	"go.opencensus.io/plugin/ochttp"
+	"google.golang.org/grpc"
+)
+
+var _ server = (*gatewayServer)(nil)
+
+type gatewayServer struct {
+	internalHTTPServer *http.Server
+}
+
+func (s *gatewayServer) Serve(listener net.Listener) error {
+	err := s.internalHTTPServer.Serve(listener)
+	if err != nil && !errors.Is(err, http.ErrServerClosed) {
+		return err
+	}
+
+	return nil
+}
+
+func (s *gatewayServer) Close() error {
+	return s.internalHTTPServer.Shutdown(context.Background())
+}
+
+// nolint: revive // false-positive, it reports tracing as a control flag.
+func newGatewayServerWithListener(
+	muxOptions []runtime.ServeMuxOption,
+	tracing bool,
+	registerGateway registerGatewayFunc,
+	address string,
+	middlewares chi.Middlewares,
+) (
+	*serverWithListener,
+	error,
+) {
+	grpcGatewayMux := runtime.NewServeMux(
+		muxOptions...,
+	)
+
+	var handler http.Handler = grpcGatewayMux
+
+	if tracing {
+		handler = &ochttp.Handler{
+			Handler:     grpcGatewayMux,
+			Propagation: &propagation.HTTPFormat{},
+		}
+	}
+
+	if registerGateway != nil {
+		dialOptions := []grpc.DialOption{
+			grpc.WithInsecure(),
+			grpc.WithStatsHandler(&ocgrpc.ClientHandler{}),
+		}
+
+		registerGateway(grpcGatewayMux, dialOptions)
+	}
+
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return nil, fmt.Errorf("new listener: %w", err)
+	}
+
+	corsHandler := cors.New(cors.Options{
+		AllowedMethods:   []string{"GET", "POST", "PATCH", "PUT", "DELETE"},
+		AllowedHeaders:   []string{"Accept", "Authorization", "Content-Type"},
+		ExposedHeaders:   []string{"Link", "X-Total-Count"},
+		AllowCredentials: true,
+	})
+
+	r := chi.NewRouter()
+
+	r.Use(middlewares...)
+	r.Use(corsHandler.Handler)
+	r.Get(
+		"/",
+		func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		},
+	)
+	r.Mount("/", handler)
+
+	return &serverWithListener{
+			server: &gatewayServer{
+				internalHTTPServer: &http.Server{
+					Handler: r,
+				},
+			},
+			listener: listener,
+		},
+		nil
+}

--- a/grpc/grpc_server.go
+++ b/grpc/grpc_server.go
@@ -1,0 +1,123 @@
+package grpc
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"strconv"
+
+	"contrib.go.opencensus.io/exporter/stackdriver"
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"go.opencensus.io/plugin/ocgrpc"
+	"go.opencensus.io/trace"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+var _ server = (*grpcServer)(nil)
+
+type grpcServer struct {
+	internalGRPCServer *grpc.Server
+}
+
+func (s *grpcServer) Serve(listener net.Listener) error {
+	return s.internalGRPCServer.Serve(listener)
+}
+
+func (s *grpcServer) Close() error {
+	s.internalGRPCServer.GracefulStop()
+
+	return nil
+}
+
+func newGRPCServerWithListener(
+	listener net.Listener,
+	address string,
+	tracing bool,
+	grpcServerOptions []grpc.ServerOption,
+	unaryServerInterceptors []grpc.UnaryServerInterceptor,
+	registerServer registerServerFunc,
+) (
+	*serverWithListener,
+	error,
+) {
+	grpcListener, err := newGRPCListener(listener, address)
+	if err != nil {
+		return nil, fmt.Errorf("new grpc listener: %w", err)
+	}
+
+	grpcServerOptions, err = setGRPCTracing(tracing, grpcServerOptions)
+	if err != nil {
+		return nil, fmt.Errorf("set grpc tracing tracing: %w", err)
+	}
+
+	if len(unaryServerInterceptors) > 0 {
+		grpcServerOptions = append(grpcServerOptions,
+			grpc_middleware.WithUnaryServerChain(
+				unaryServerInterceptors...,
+			))
+	}
+
+	internalGRPCServer := grpc.NewServer(grpcServerOptions...)
+
+	reflection.Register(internalGRPCServer)
+
+	if registerServer != nil {
+		registerServer(internalGRPCServer)
+	}
+
+	return &serverWithListener{
+		server: &grpcServer{
+			internalGRPCServer: internalGRPCServer,
+		},
+		listener: grpcListener,
+	}, nil
+}
+
+// nolint: revive // false-positive, it reports tracing as a control flag.
+func setGRPCTracing(
+	tracing bool,
+	serverOptions []grpc.ServerOption,
+) ([]grpc.ServerOption, error) {
+	if !tracing {
+		return serverOptions, nil
+	}
+
+	exporter, err := stackdriver.NewExporter(stackdriver.Options{
+		ProjectID: os.Getenv("GOOGLE_CLOUD_PROJECT"),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("new exporter: %w", err)
+	}
+
+	trace.RegisterExporter(exporter)
+	trace.ApplyConfig(trace.Config{DefaultSampler: trace.AlwaysSample()})
+
+	return append(
+		serverOptions,
+		grpc.StatsHandler(&ocgrpc.ServerHandler{}),
+	), nil
+}
+
+func newGRPCListener(listener net.Listener, addr string) (net.Listener, error) {
+	if listener != nil {
+		return listener, nil
+	}
+
+	hostString, portString, err := net.SplitHostPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("invalid address: %w", err)
+	}
+
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		return nil, fmt.Errorf("parse port: %w", err)
+	}
+
+	listener, err = net.Listen("tcp", fmt.Sprintf("%s:%d", hostString, port-1))
+	if err != nil {
+		return nil, fmt.Errorf("new net listener: %w", err)
+	}
+
+	return listener, nil
+}

--- a/grpc/readme.go
+++ b/grpc/readme.go
@@ -1,0 +1,8 @@
+// Package grpc implements a smart wrapper over the grpc
+// ecosystem. It provides bootstrapping for launching
+// a production ready grpc server alongside a grpc gateway server.
+//
+// It also wraps the most common grpc parameters used in the company
+// in the options.
+//
+package grpc

--- a/logs/zap.go
+++ b/logs/zap.go
@@ -14,8 +14,12 @@ func NewLogger() (*zap.Logger, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer logger.Sync() // flushes buffer, if any
+
 	return logger, nil
+}
+
+func NewExampleLogger() *zap.Logger {
+	return zap.NewExample()
 }
 
 type StructuredLoggerEntry struct {


### PR DESCRIPTION
- refactored the constructor to use the standard design of the servers found in standard library and grpc package.
- refactored the file structure to have separate files for grpc and gateway servers.
- removed os.Exit calls from the package.
- removed the port option as it was given the fact that we have the address option.
- disabled default logging and added a debug option that enables debug logging.
- added linter and CI workflow.
- added Option wrappers over common logic used in most projects.