### PR TITLE
Fix/errors

### DIFF
--- a/errors/error.go
+++ b/errors/error.go
@@ -38,6 +38,8 @@ func (t ErrorType) HTTPStatus() int {
 		return http.StatusForbidden
 	case ErrorTypeUnauthenticated:
 		return http.StatusUnauthorized
+	case ErrorTypeAlreadyExists:
+		return http.StatusConflict
 	case ErrorTypeInternalError, ErrorTypePanic:
 		return http.StatusInternalServerError
 	default:
@@ -52,6 +54,7 @@ const (
 	ErrorTypeUnprocessableContent ErrorType = "unprocessable-content"
 	ErrorTypeUnauthorized         ErrorType = "unauthorzied"
 	ErrorTypeUnauthenticated      ErrorType = "unauthenticated"
+	ErrorTypeAlreadyExists        ErrorType = "already-exists"
 	ErrorTypeInternalError        ErrorType = "internal-error"
 	ErrorTypePanic                ErrorType = "panic"
 )

--- a/errors/error.go
+++ b/errors/error.go
@@ -35,7 +35,7 @@ func (t ErrorType) HTTPStatus() int {
 	case ErrorTypeUnprocessableContent:
 		return http.StatusUnprocessableEntity
 	case ErrorTypeUnauthorized:
-		return http.StatusUnauthorized
+		return http.StatusForbidden
 	case ErrorTypeUnauthenticated:
 		return http.StatusUnauthorized
 	case ErrorTypeInternalError, ErrorTypePanic:

--- a/errors/errorsgrpc/errorsgrpc.go
+++ b/errors/errorsgrpc/errorsgrpc.go
@@ -73,6 +73,7 @@ var errorTypeToStatusCode = map[errors.ErrorType]codes.Code{
 	errors.ErrorTypeUnprocessableContent: codes.Internal,
 	errors.ErrorTypeUnauthorized:         codes.PermissionDenied,
 	errors.ErrorTypeUnauthenticated:      codes.Unauthenticated,
+	errors.ErrorTypeAlreadyExists:        codes.AlreadyExists,
 	errors.ErrorTypeInternalError:        codes.Internal,
 }
 


### PR DESCRIPTION
The HTTP status for the unauthorized error should be forbidden.

It also adds the already exists error type.