### PR TITLE
fix(pubsub/pubsub.go): remove Ack from Event

### DIFF
--- a/pubsub/pubsub.go
+++ b/pubsub/pubsub.go
@@ -53,8 +53,4 @@ type Event[T, P any] struct {
 
 	// Carries an error produced by the underlying subscriber.
 	Error error
-
-	// Ack should be called to acknowledge the event if the processing
-	// of the event was successful.
-	Ack func()
 }


### PR DESCRIPTION
Forgot to remove the Ack from the Event type.