### PR TITLE
feat(http,sentry): chi+slog logger + chi sentry middleware

### DIFF
--- a/http/CHANGELOG.md
+++ b/http/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog — `go-commons/http`
+
+All notable changes to the `github.com/purposeinplay/go-commons/http`
+module are documented here.
+
+## [http/v0.0.2]
+
+### Added
+
+- **`NewStructuredLogger(*slog.Logger)`** — chi `RequestLogger`
+  middleware backed by stdlib `log/slog`. Emits `request started` /
+  `request complete` events per request, decorated with method, path,
+  request ID, scheme, proto, remote addr, user agent, and full URI.
+  Pairs with the existing zap-based `go-commons/logs` for projects
+  ready to migrate to slog.
+- **`StructuredLoggerEntry`** — slog-backed per-request log entry,
+  with `Write` / `Panic` / `WithError` callbacks for chi.
+- **`GetSlogEntry(*http.Request)`** — fetch the current request's
+  slog-based entry. Distinct name from the existing zap-based
+  `GetLogEntry` so consumers in mid-migration can tell them apart.
+
+### Internal
+
+- Module bumped to `go 1.24` (required for `log/slog`).
+
+## [http/v0.0.1]
+
+Initial release of the `http` subpackage with `OAuthError`,
+`HTTPError`, response builders (`BadRequestError`, etc.),
+`HandleError`, plus the `render` and `router` sub-subpackages.

--- a/http/go.mod
+++ b/http/go.mod
@@ -1,6 +1,6 @@
 module github.com/purposeinplay/go-commons/http
 
-go 1.17
+go 1.24
 
 require (
 	github.com/go-chi/chi/v5 v5.0.7

--- a/http/structuredlog.go
+++ b/http/structuredlog.go
@@ -1,0 +1,122 @@
+package http
+
+import (
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	chimiddleware "github.com/go-chi/chi/v5/middleware"
+)
+
+// NewStructuredLogger returns a chi-compatible request-logging middleware
+// backed by stdlib log/slog. It emits one "request started" event per
+// incoming request and one "request complete" event per response, both
+// decorated with method, path, request ID, scheme, proto, remote addr,
+// user agent, and full URI.
+//
+// Usage:
+//
+//	r := chi.NewRouter()
+//	r.Use(http.NewStructuredLogger(slog.Default()))
+//
+// To plug in a custom slog.Handler:
+//
+//	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+//	r.Use(http.NewStructuredLogger(logger))
+//
+// The corresponding StructuredLoggerEntry can be retrieved per-request
+// via GetLogEntry(r).
+func NewStructuredLogger(
+	logger *slog.Logger,
+) func(next http.Handler) http.Handler {
+	return chimiddleware.RequestLogger(&structuredLogger{logger: logger})
+}
+
+type structuredLogger struct {
+	logger *slog.Logger
+}
+
+// NewLogEntry creates a new log entry with attributes that add context to
+// help identify it. The returned entry is updated in-place across the
+// Write / Panic callbacks chi makes during the request lifecycle.
+func (l *structuredLogger) NewLogEntry(req *http.Request) chimiddleware.LogEntry {
+	scheme := "http"
+	if req.TLS != nil {
+		scheme = "https"
+	}
+
+	attrs := []any{
+		slog.String("component", "api"),
+		slog.String("method", req.Method),
+		slog.String("path", req.URL.Path),
+		slog.String("http.scheme", scheme),
+		slog.String("http.proto", req.Proto),
+		slog.String("http.method", req.Method),
+		slog.String("remote_addr", req.RemoteAddr),
+		slog.String("user_agent", req.UserAgent()),
+		slog.String("uri", fmt.Sprintf("%s://%s%s", scheme, req.Host, req.RequestURI)),
+	}
+
+	if reqID := chimiddleware.GetReqID(req.Context()); reqID != "" {
+		attrs = append(attrs, slog.String("req.id", reqID))
+	}
+
+	entry := &StructuredLoggerEntry{Logger: l.logger.With(attrs...)}
+	entry.Logger.Info("request started")
+
+	return entry
+}
+
+// StructuredLoggerEntry is the per-request log entry chi mutates across
+// the request lifecycle (start → write → panic).
+type StructuredLoggerEntry struct {
+	Logger *slog.Logger
+}
+
+// Write adds response context to the entry and emits "request complete".
+func (l *StructuredLoggerEntry) Write(
+	status, bytes int,
+	_ http.Header,
+	elapsed time.Duration,
+	_ any,
+) {
+	elapsedMs := float64(elapsed.Nanoseconds()) / 1_000_000.0
+	l.Logger = l.Logger.With(
+		slog.Int("res.status", status),
+		slog.Int("res.bytes_length", bytes),
+		slog.Float64("res.elapsed_ms", elapsedMs),
+	)
+	l.Logger.Info("request complete")
+}
+
+// Panic adds panic context to the entry. chi calls this and Write (with
+// status 500) so we don't emit a separate event here — the recoverer
+// downstream emits the explicit panic log.
+func (l *StructuredLoggerEntry) Panic(v any, stack []byte) {
+	l.Logger = l.Logger.With(
+		slog.String("stack", string(stack)),
+		slog.String("panic", fmt.Sprintf("%+v", v)),
+	)
+}
+
+// WithError annotates the entry with an error attribute and returns the
+// updated logger.
+func (l *StructuredLoggerEntry) WithError(err error) *slog.Logger {
+	l.Logger = l.Logger.With(slog.Any("error", err))
+	return l.Logger
+}
+
+// GetSlogEntry returns the in-context StructuredLoggerEntry for a
+// request, or nil if no structured logger middleware is on the chain.
+//
+// Distinct from the existing GetLogEntry (which returns the zap-based
+// entry from go-commons/logs) so consumers that mix both during a
+// migration can tell them apart.
+func GetSlogEntry(r *http.Request) *StructuredLoggerEntry {
+	entry, ok := chimiddleware.GetLogEntry(r).(*StructuredLoggerEntry)
+	if !ok {
+		return nil
+	}
+	return entry
+}

--- a/sentry/CHANGELOG.md
+++ b/sentry/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog — `go-commons/sentry`
+
+All notable changes to the `github.com/purposeinplay/go-commons/sentry`
+module are documented here.
+
+## [sentry/v0.0.5]
+
+### Added
+
+- **`Middleware(*Client) func(next http.Handler) http.Handler`** — chi-
+  compatible HTTP middleware that recovers from panics, reports them to
+  Sentry via `sentrygo.CurrentHub().Recover(rvr)`, and flushes the
+  client's buffered events at the end of the request via
+  `client.Close()`. Pair with `chi/middleware.Recoverer` (or
+  equivalent) if you also need a 500 response written for the client.
+
+  Logging on Close errors goes through `slog.Default()`.
+
+## [sentry/v0.0.1] – [sentry/v0.0.4]
+
+Existing `Client` with `NewClient`, `CaptureException`, `Close`, etc.
+See git history for per-version changes.

--- a/sentry/middleware.go
+++ b/sentry/middleware.go
@@ -1,0 +1,48 @@
+package sentry
+
+import (
+	"log/slog"
+	"net/http"
+
+	sentrygo "github.com/getsentry/sentry-go"
+)
+
+// Middleware returns a chi-compatible HTTP middleware that recovers from
+// panics inside the request handler chain, reports them to Sentry via
+// the supplied Client, and flushes the buffered events when the request
+// ends.
+//
+// Usage:
+//
+//	r := chi.NewRouter()
+//	client, _ := sentry.NewClient(dsn, env, release, sampleRate)
+//	r.Use(sentry.Middleware(client))
+//
+// On panic, the middleware:
+//  1. Calls sentry.CurrentHub().Recover(rvr) to capture the event.
+//  2. Calls client.Close() to flush buffered events before the
+//     response is finalised.
+//
+// The recovered panic is NOT re-raised by this middleware; pair with
+// chi's middleware.Recoverer (or an equivalent) if you also need a 500
+// response written for the client.
+func Middleware(client *Client) func(next http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer func() {
+				if rvr := recover(); rvr != nil {
+					sentrygo.CurrentHub().Recover(rvr)
+				}
+
+				if err := client.Close(); err != nil {
+					slog.Default().Error(
+						"closing sentry on request end",
+						slog.Any("error", err),
+					)
+				}
+			}()
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}


### PR DESCRIPTION
Two additive changes — no breaking, no consumers affected.

## http (http/v0.0.2)
- `NewStructuredLogger(*slog.Logger)` — chi RequestLogger middleware backed by stdlib log/slog
- `StructuredLoggerEntry`, `GetSlogEntry` helpers
- Module bumped to go 1.24

## sentry (sentry/v0.0.5)
- `Middleware(*Client)` — chi panic-recover + sentry-flush-on-end middleware

## Source
Both functions are ports of code previously in originals-commons
(`logs/logs.go` and `middleware/sentrydsn.go`). After this lands,
originals-commons can retire those copies.

## Test plan
- [x] `go build ./...` clean for both subpackages
- [x] `go vet ./...` clean
- [ ] Plinko integration follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)